### PR TITLE
Use STATICPOPUP_NUMDIALOGS only when defined

### DIFF
--- a/LootThis.lua
+++ b/LootThis.lua
@@ -24,15 +24,27 @@ f:SetScript("OnEvent", function(this, event, ...)
 				end
 			end
 			if autoconfirm == true then
-				for i = 1, STATICPOPUP_NUMDIALOGS do
-					local frame = _G["StaticPopup"..i]
-					if frame.which == "LOOT_BIND" and frame:IsVisible() then StaticPopup_OnClick(frame, 1) end
+				if STATICPOPUP_NUMDIALOGS then
+					for i = 1, STATICPOPUP_NUMDIALOGS do
+						local frame = _G["StaticPopup"..i]
+						if frame.which == "LOOT_BIND" and frame:IsVisible() then StaticPopup_OnClick(frame, 1) end
+					end
+				else
+					StaticPopup_ForEachShownDialog(function(frame)
+						if frame.which == "LOOT_BIND" and frame:IsVisible() then StaticPopup_OnClick(frame, 1) end
+					end)
 				end
 				this:UnregisterEvent("LOOT_BIND_CONFIRM")
 				LootSlot(slotID)
-				for i = 1, STATICPOPUP_NUMDIALOGS do
-					local frame = _G["StaticPopup"..i]
-					if frame.which == "LOOT_BIND" and frame:IsVisible() then StaticPopup_OnClick(frame, 1) end
+				if STATICPOPUP_NUMDIALOGS then
+					for i = 1, STATICPOPUP_NUMDIALOGS do
+						local frame = _G["StaticPopup"..i]
+						if frame.which == "LOOT_BIND" and frame:IsVisible() then StaticPopup_OnClick(frame, 1) end
+					end
+				else
+					StaticPopup_ForEachShownDialog(function(frame)
+						if frame.which == "LOOT_BIND" and frame:IsVisible() then StaticPopup_OnClick(frame, 1) end
+					end)
 				end
 				ConfirmLootSlot(slotID)
 				this:RegisterEvent("LOOT_BIND_CONFIRM")

--- a/LootThis.toc
+++ b/LootThis.toc
@@ -1,6 +1,6 @@
-## Interface: 50500
+## Interface: 50501
 ## Title: LootThis
 ## Notes: Automatically confirm BoP items when in a dungeon solo
 ## Author: GovtGeek
-## Version: 5.5.0.0
+## Version: 5.5.0.1
 LootThis.lua


### PR DESCRIPTION
Now use StaticPopup_ForEachShownDialog when STATICPOPUP_NUMDIALOGS is not defined